### PR TITLE
Allow underscore in parameter names

### DIFF
--- a/Data/Text/Format/Heavy/Parse/Braces.hs
+++ b/Data/Text/Format/Heavy/Parse/Braces.hs
@@ -43,7 +43,7 @@ pVariable = do
     return $ FVariable (TL.pack name) fmt
   where
     variable = do
-      name <- many $ try alphaNum <|> try (char '-') <|> char '.'
+      name <- many $ try alphaNum <|> try (char '-') <|> char '.' <|> char '_'
       mbColon <- optionMaybe $ char ':'
       fmt <- case mbColon of
                Nothing -> return Nothing

--- a/package.yaml
+++ b/package.yaml
@@ -57,6 +57,8 @@ tests:
       - base >= 4.8 && < 5
       - time >= 1.5
       - text-format-heavy
+      - containers
+      - text
       - hspec
 
 github: portnov/text-format-heavy

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -39,6 +39,10 @@ main = hspec $ do
         format "one: {the-key}!"
           ((Map.singleton "the-key" "the string") :: Map Text Text)
             `shouldBe` "one: the string!"
+      it "with underscores" $ do
+        format "one: {the_key}!"
+          ((Map.singleton "the_key" "the string") :: Map Text Text)
+            `shouldBe` "one: the string!"
 
   describe "documentation" $ do
     it "formats examples from wiki" $ do

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -2,6 +2,9 @@
 
 import Test.Hspec
 import Data.Time
+import qualified Data.Map as Map
+import Data.Map (Map)
+import Data.Text.Lazy (Text)
 
 import Data.Text.Format.Heavy
 import Data.Text.Format.Heavy.Time
@@ -22,6 +25,20 @@ main = hspec $ do
     it "handles parameter numbers" $ do
       format "one: {0}, two: {1}" ((1:: Int), (2::Int)) `shouldBe` "one: 1, two: 2"
       format "two: {1}, one: {0}" ((1:: Int), (2::Int)) `shouldBe` "two: 2, one: 1"
+
+    describe "handles parameters names" $ do
+      it "with ascii characters" $ do
+        format "one: {theKey}!"
+          ((Map.singleton "theKey" "the string") :: Map Text Text)
+            `shouldBe` "one: the string!"
+      it "with dots" $ do
+        format "one: {the.key}!"
+          ((Map.singleton "the.key" "the string") :: Map Text Text)
+            `shouldBe` "one: the string!"
+      it "with dashes" $ do
+        format "one: {the-key}!"
+          ((Map.singleton "the-key" "the string") :: Map Text Text)
+            `shouldBe` "one: the string!"
 
   describe "documentation" $ do
     it "formats examples from wiki" $ do

--- a/text-format-heavy.cabal
+++ b/text-format-heavy.cabal
@@ -80,4 +80,6 @@ test-suite spec
     , hspec
     , text-format-heavy
     , time >=1.5
+    , containers
+    , text
   default-language: Haskell2010


### PR DESCRIPTION
With this change `_` is supported in identifiers when using named parameters in the format (e.g. `{some_key}`.

Solves: https://github.com/portnov/text-format-heavy/issues/7