### PR TITLE
Relax version bounds on text (from <2.1 to <2.2)

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -38,7 +38,7 @@ library:
   source-dirs: .
   dependencies:
       - base >=4.8 && <5
-      - text >=1.2 && <1.3
+      - text >=1.2 && <2.2
       - bytestring >= 0.10
       - parsec >=3.1 && <3.2
       - containers >= 0.5

--- a/text-format-heavy.cabal
+++ b/text-format-heavy.cabal
@@ -62,7 +62,7 @@ library
     , labels
     , parsec >=3.1 && <3.2
     , template-haskell >=2.8
-    , text >=1.2 && <2.1
+    , text >=1.2 && <2.2
     , th-lift
     , th-lift-instances
     , time >=1.5


### PR DESCRIPTION
With this change this library builds on GHC 9.10 and 9.12, which wasn't the case before.

This is very useful to me as I am currently depending on a fork of text-format-heavy where I increased the version bound myself, instead of the hackage version of text-format-heavy.

I would love to see this updated version on Hackage.

I tested this change with GHC 9.2 / 9.4 / 9.6 / 9.8 / 9.10 / 9.12